### PR TITLE
Update .travis.yml for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,24 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 matrix:
   allow_failures:
     - php: 5.6
+    - php: 7.0
     - php: hhvm
 env:
-  - MAGENTO_VERSION=magento-ce-1.9.1.0
-  - MAGENTO_VERSION=magento-ce-1.9.0.1
-  - MAGENTO_VERSION=magento-ce-1.8.1.0
-  - MAGENTO_VERSION=magento-ce-1.8.0.0
-  - MAGENTO_VERSION=magento-ce-1.7.0.2
-  - MAGENTO_VERSION=magento-ce-1.6.2.0
+  - MAGENTO_VERSION=magento-mirror-1.9.2.2
+  - MAGENTO_VERSION=magento-mirror-1.9.2.1
+  - MAGENTO_VERSION=magento-mirror-1.9.2.0
+  - MAGENTO_VERSION=magento-mirror-1.9.1.1
+  - MAGENTO_VERSION=magento-mirror-1.9.1.0
+  - MAGENTO_VERSION=magento-mirror-1.9.0.1
+  - MAGENTO_VERSION=magento-mirror-1.9.0.0
+  - MAGENTO_VERSION=magento-mirror-1.8.1.0
+  - MAGENTO_VERSION=magento-mirror-1.8.0.0
+  - MAGENTO_VERSION=magento-mirror-1.7.0.2
+  - MAGENTO_VERSION=magento-mirror-1.6.2.0
 script:
   - curl -sSL https://raw.githubusercontent.com/AOEpeople/MageTestStand/master/setup.sh | bash


### PR DESCRIPTION
Since original Magento download links are inactive we should use mirrors.
See https://github.com/netz98/n98-magerun/issues/722
